### PR TITLE
修复ＢＵＧ

### DIFF
--- a/resource/GameData/DTS_zh/zh.xml
+++ b/resource/GameData/DTS_zh/zh.xml
@@ -4198,7 +4198,7 @@ Looking for ]]>
   <string id="134477"><![CDATA[<color=orange>[]]></string>
   <string id="134508"><![CDATA[]: Cannot deploy while stowed.</color>]]></string>
   <string id="134585"><![CDATA[运动中..]]></string>
-  <string id="134604"><![CDATA[地位]]></string>
+  <string id="134604" noT="1"><![CDATA[status]]></string>
   <string id="134617"><![CDATA[A]]></string>
   <string id="134620"><![CDATA[切换]]></string>
   <string id="134633"><![CDATA[HeatAnimationEmissive]]></string>


### PR DESCRIPTION
修复翻译造成的部件无打开动作和部件脱离#67，目前已知道的部件消失造成的相机脱离飞船的ＢＵＧ不在发生，是否已经解决#58和#62还有待进一步测试。