### PR TITLE
测试修复部件消失发现的ＢＵＧ

### DIFF
--- a/resource/GameData/DTS_zh/zh.xml
+++ b/resource/GameData/DTS_zh/zh.xml
@@ -4326,7 +4326,7 @@ Looking for ]]>
   <string id="138705"><![CDATA[dockNodeIdx]]></string>
   <string id="138728"><![CDATA[DOCKEDVESSEL]]></string>
   <string id="138753"><![CDATA[准备好了]]></string>
-  <string id="138764"><![CDATA[解锁]]></string>
+  <string id="138764" noT="1"><![CDATA[Undock]]></string>
   <string id="138777"><![CDATA[UndockSameVessel]]></string>
   <string id="138810"><![CDATA[EnableXFeed]]></string>
   <string id="138833"><![CDATA[DisableXFeed]]></string>


### PR DESCRIPTION
该处翻译会造成飞船装载对接口等部件后，飞行中部件会消失的ＢＵＧ，连带消失后相机脱离飞船。#62和#58，继续测试中。