### PR TITLE
行政大厅百分比滑块消失BUG

### DIFF
--- a/resource/GameData/DTS_zh/zh.xml
+++ b/resource/GameData/DTS_zh/zh.xml
@@ -754,7 +754,7 @@
   <string id="10482"><![CDATA[DoURL]]></string>
   <string id="10493"><![CDATA[A null layer sprite was encountered on control "]]></string>
   <string id="10590" noT="2"><![CDATA[". Please fill in the layer reference, or remove the empty element.]]></string>
-  <string id="10726"><![CDATA[一般]]></string>
+  <string id="10726" noT="1"><![CDATA[normal]]></string>
   <string id="10739"><![CDATA[加速]]></string>
   <string id="10748"><![CDATA[启用]]></string>
   <string id="10761"><![CDATA[关闭]]></string>


### PR DESCRIPTION
该处翻译后会造成生涯模式中的行政大厅内调整百分比的滑块消失的BUG。
![360 20150622140345960](https://cloud.githubusercontent.com/assets/12621656/8276456/12d8e578-18e9-11e5-955d-5e75bd691b49.jpg)
![360 20150622140547075](https://cloud.githubusercontent.com/assets/12621656/8276457/17d292ea-18e9-11e5-9bbb-9cd653e1ba60.jpg)
