### PR TITLE
修复滚动条消失的BUG

### DIFF
--- a/resource/GameData/DTS_zh/zh.xml
+++ b/resource/GameData/DTS_zh/zh.xml
@@ -749,8 +749,8 @@
 <string id="10493"><![CDATA[A null layer sprite was encountered on control "]]></string>
 <string id="10590" noT="2"><![CDATA[". Please fill in the layer reference, or remove the empty element.]]></string>
 <string id="10726" noT="1"><![CDATA[normal]]></string>
-<string id="10739"><![CDATA[加速]]></string>
-<string id="10748"><![CDATA[启用]]></string>
+<string id="10739" noT="1"><![CDATA[over]]></string>
+<string id="10748" noT="1"><![CDATA[active]]></string>
 <string id="10761"><![CDATA[关闭]]></string>
 <string id="10778" noT="1"><![CDATA[Normal]]></string>
 <string id="10791" noT="1"><![CDATA[Over]]></string>

--- a/resource/GameData/DTS_zh/zh.xml
+++ b/resource/GameData/DTS_zh/zh.xml
@@ -7583,11 +7583,11 @@ Note that this page is added with AddState instead of AddPage, because we don't 
 <string id="318691"><![CDATA[要两个对接口接触,先得对其两个对接口这意味着两个对接口的顺行向量重合.幸运的是有很多工具帮助玩家完成这一任务
 
 - 按 []]></string>
-<string id="319311"><![CDATA[] to find one of your liking, I recommend the Chase mode for this task.
+<string id="319311"><![CDATA[]找到一个你喜欢的,我建议你尽快完成这个任务.
 
-- Apart from Staging mode, your HUD also has a Docking mode, press the Docking button under the stages on the lower left of the screen. What this does is change the control scheme from rotation to translation, so your W, A, S, D keys will control translation and LeftShift and LeftControl are up and down, a bit like controlling a Kerbal EVA.
+- 除了分段模式, 你的HUD还具有一个对接模式, 按下在屏幕的左下角的阶段对接按钮. 这样做是从旋转控制改变为平移控制, 让您的 W, A, S, D键控制平移和左Shift键和左侧Control控制向上向下,有点像控制Kerbal EVA。
 
-- Using docking mode isn't strictly necessary. Use whichever mode works best for you, but remember you can use the I, K, J, L, H and N to translate in the normal Staging mode, you can check the key bindings at any time in the Pause Menu. ]]></string>
+- 使用对接模式并不是必需的. 无论哪种模式最适合你. 但请记住, 你可以使用 I, K, J, L, H和N在正常和临时模式之间转换, 你可以任何时间在暂停菜单中检查键绑定的. ]]></string>
 <string id="320623"><![CDATA[无论用什么方法玩家必须对其两个对接口并使其尽可能靠近,若两个对接口距离一米以内对接口就会由磁力吸到一起.
 
 这一步留给玩家自行练习,担心搞砸的话可以使用快速存档功能,[]]></string>


### PR DESCRIPTION
修复两处翻译后会造成研发中心的上下滚动条和左右滚动条消失，具体表现为：鼠标移动到滚动条位置上滚动条消失（ID10739）和点击滚动条也会消失（ID10748）
